### PR TITLE
new grouping and applyBindingsWithValidation

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -651,7 +651,7 @@
     };
 
     ko.applyBindingsWithValidation = function (viewModel, rootNode, options) {
-        
+        //TODO: support variable number of parameters to imitate ko.applyBindings
         ko.validation.init(options);
         ko.validation.group(viewModel);
         ko.applyBindings(viewModel, rootNode);


### PR DESCRIPTION
new grouping supports deep, recursive traversing of objects tree and also can be on-the-fly rather than observable based

a stage before attempt to remove init and have settings per view model

closes #12
