### PR TITLE
Added the switch to add the error class on the input field as well.

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -10,7 +10,7 @@
         messageTemplate: null,
         insertMessages: true,
         parseInputAttributes: false,
-        addClassToField: true,
+        addClassToField: false,
         errorMessageClass: 'validationMessage'
     };
 
@@ -252,9 +252,6 @@
                         ko.renderTemplate(config.messageTemplate, { field: valueAccessor() }, null, validationMessageElement, 'replaceNode');
                     } else {
                         ko.applyBindingsToNode(validationMessageElement, { validationMessage: valueAccessor() });
-                    }
-                    if(config.addClassToField){
-                        ko.applyBindingsToNode(element, { css: { error: valueAccessor() } });
                     }
                 }
             };


### PR DESCRIPTION
This will add the error class on the failing field as well as the span tag.  This will enable a visual highlighting on the offending field in addition to the text that's generated.
