### PR TITLE
New isAnyMessageShown() method to validatedObservable

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -871,9 +871,6 @@
         obsv.isValid = ko.computed(function () {
             return obsv.errors().length === 0;
         });
-        obsv.isAnyMessageShown = ko.computed(function () {
-            return initialValue.isAnyMessageShown();
-        });
 
         return obsv;
     };

--- a/Tests/validation-tests.js
+++ b/Tests/validation-tests.js
@@ -936,7 +936,7 @@ test('validatedObservable does not show error message when not modified', functi
     });
 
     ok(obj(), 'observable works');
-    ok(!obj.isAnyMessageShown(), 'validation error message is hidden');
+    ok(!obj().isAnyMessageShown(), 'validation error message is hidden');
 
 });
 
@@ -951,7 +951,7 @@ test('validatedObservable does not show error message when modified but correct'
     obj().testObj2('a');
 
     ok(obj(), 'observable works');
-    ok(!obj.isAnyMessageShown(), 'validation error message is hidden');
+    ok(!obj().isAnyMessageShown(), 'validation error message is hidden');
 
 });
 
@@ -964,7 +964,7 @@ test('validatedObservable show error message when at least one invalid and modif
     obj().testObj.isModified(true);
 
     ok(obj(), 'observable works');
-    ok(obj.isAnyMessageShown(), 'validation error message is shown');
+    ok(obj().isAnyMessageShown(), 'validation error message is shown');
 
 });
 


### PR DESCRIPTION
There are times where I want to show a general message when there is a message error being shown.

For example, I want to show a general message at the bottom of the form saying something like 'There are validation error. Please fix them.'. As this is a new object which values are not valid, the isValid() method does not work, as I need to go though all the fields and see if any of them is invalid and has been modified.

For that I added a new isAnyMessageShown() to validatedObservable.

The corresponding tests were also added.

Thanks
