### PR TITLE
Avoid strange error when property not defined

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -64,7 +64,7 @@
                 return node.getAttribute(attr) !== null;
             },
             isValidatable: function (o) {
-                return o.rules && o.isValid && o.isModified;
+                return o && o.rules && o.isValid && o.isModified;
             },
             insertAfter: function (node, newNode) {
                 node.parentNode.insertBefore(newNode, node.nextSibling);


### PR DESCRIPTION
You get a strange error when certain properties are undefined.

> Cannot read property 'rules' of undefined

Probably best to throw a sensible error message or fail gracefully. 
