### PR TITLE
Fix to missed update of the isValidating property

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -801,6 +801,7 @@
             }
 
             if (isValid) {//its VALID, so don't mess up anything that may have happened synchronously earlier on
+                observable.isValidating(false);
                 return;
             }
 


### PR DESCRIPTION
The isValidating property at async rule processing was not updated when the rule in question was valid.
