### PR TITLE
Fix for issue #82

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -689,12 +689,12 @@
                 msg = null,
                 isModified = false,
                 isValid = false;
-                
+
             obsv.extend({ validatable: true });
 
             isModified = obsv.isModified();
             isValid = obsv.isValid();
-            
+
             // create a handler to correctly return an error message
             var errorMsgAccessor = function () {
                 if (!config.messagesOnModified || isModified) {
@@ -875,6 +875,8 @@
 
             //not valid, so format the error message and stick it in the 'error' variable
             observable.error = ko.validation.formatMessage(ctx.message || rule.message, ctx.params);
+            observable.errorRule = rule;
+            observable.errorContext = ctx;
             observable.__valid__(false);
             return false;
         } else {
@@ -923,6 +925,14 @@
             ctx, // the current Rule Context for the loop
             ruleContexts = observable.rules(), //cache for iterator
             len = ruleContexts.length; //cache for iterator
+        
+            // If there is an assigned error rule then check to see if it is still an error, if it isn't reset the valid status
+            if(observable.errorRule) {
+                if(validateSync(observable,observable.errorRule,observable.errorContext)) {
+                    observable.error = null;
+                    observable.__valid__(true);
+                }
+            }
 
         for (; i < len; i++) {
 


### PR DESCRIPTION
Hi @ericmbarnard,

Calling utils.isValidatable, coming from line 639:

``` javascript
if (config.insertMessages && utils.isValidatable(valueAccessor())) {
```

In some cases in my app (for more complicated screens) valueAccessor() is sometimes undefined, so I've added a small check to first make sure there is a valid extended observable before calling 

``` javascript
o.rules && o.isValid && o.isModified;
```
