### PR TITLE
Bugfix for isValidatable with undefined parameter

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -67,7 +67,7 @@
                 return node.getAttribute(attr) !== null;
             },
             isValidatable: function (o) {
-                return o.rules && o.isValid && o.isModified;
+                return o && o.rules && o.isValid && o.isModified;
             },
             insertAfter: function (node, newNode) {
                 node.parentNode.insertBefore(newNode, node.nextSibling);


### PR DESCRIPTION
It looks like I'm still getting instances where I somehow end up passing a valueAccessor which evaluates to undefined, which breaks the isValidatable function because that function doesn't check that o is not undefined.
