### PR TITLE
Show errors as 'title'/hover on input fields

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -748,12 +748,17 @@
             //add or remove class on the element;
             ko.bindingHandlers.css.update(element, cssSettingsAccessor);
 
-            // should return either attr: {title: errormsg} or attr: {title: null}
+            var origTitle = element.getAttribute('data-orig-title');
+            var elementTitle = element.title;
+            var titleIsErrorMsg = element.getAttribute('data-orig-title') == "true"
+
             var errorMsgTitleAccessor = function () {
                 if (!config.errorsAsTitleOnModified || isModified) {
-                    return { title: isValid ? null : obsv.error };
-                } else {
-                    return { title: null };
+                    if (!isValid) {
+                        return { title: obsv.error, 'data-orig-title': origTitle || elementTitle };
+                    } else {
+                        return { title: origTitle || elementTitle, 'data-orig-title': null };
+                    }
                 }
             };
             ko.bindingHandlers.attr.update(element, errorMsgTitleAccessor);

--- a/Tests/validation-ui-tests.js
+++ b/Tests/validation-ui-tests.js
@@ -66,7 +66,7 @@ test('Inserting Messages Works', function () {
 
 //#endregion
 
-//#region Showing errors as titles works
+//#region Showing errors as titles
 
 test('Showing Errors As Titles Works', function () {
 
@@ -99,6 +99,82 @@ test('Showing Errors As Titles Works', function () {
     var msg = $testInput.attr('title');
 
     equal(msg, 'This field is required.', msg);
+});
+
+test('Original titles are restored', function () {
+
+    addTestHtml('<input id="myTestInput" title="my-orig-title" data-bind="value: firstName" type="text" />');
+
+    var vm = {
+        firstName: ko.observable('').extend({ required: true })
+    };
+
+    // make sure the options are ok.
+    ko.validation.init({
+        errorsAsTitleOnModified: true,
+        decorateElement: true
+    }, true);
+
+    applyTestBindings(vm);
+
+    var $testInput = $('#myTestInput');
+
+    $testInput.val("a"); //set it 
+    $testInput.change(); //trigger change event
+
+    $testInput.val(""); //set it 
+    $testInput.change(); //trigger change event
+
+    var msg = $testInput.attr('title');
+    equal(msg, 'This field is required.', msg);
+
+    $testInput.val("a"); //set it 
+    $testInput.change(); //trigger change event
+
+    var msg = $testInput.attr('title');
+    equal(msg, 'my-orig-title', msg);
+
+});
+
+test('Original titles are restored with multiple validators, too', function () {
+
+    addTestHtml('<input id="myTestInput" title="my-orig-title" data-bind="value: firstName" type="text" />');
+
+    var vm = {
+        firstName: ko.observable('').extend({ required: true, minLength: 2 })
+    };
+
+    // make sure the options are ok.
+    ko.validation.init({
+        errorsAsTitleOnModified: true,
+        decorateElement: true
+    }, true);
+
+    applyTestBindings(vm);
+
+    var $testInput = $('#myTestInput');
+
+    $testInput.val("aa"); //set it 
+    $testInput.change(); //trigger change event
+
+    $testInput.val(""); //set it 
+    $testInput.change(); //trigger change event
+
+    var msg = $testInput.attr('title');
+    equal(msg, 'This field is required.', msg);
+
+    $testInput.val("a"); //set it 
+    $testInput.change(); //trigger change event
+
+    var msg = $testInput.attr('title');
+    equal(msg, 'Please enter at least 2 characters.', msg);
+
+    $testInput.val("aa"); //set it 
+    $testInput.change(); //trigger change event
+
+    var msg = $testInput.attr('title');
+    equal(msg, 'my-orig-title', msg);
+
 });
 
 //#endregion


### PR DESCRIPTION
I added an option, implementation and test for showing the errors on hovering the input fields (by setting the input's title attribute)
