### PR TITLE
#104 fix

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -1,10 +1,12 @@
 /*
-*   Knockout Validation
-*   Created By Eric M. Barnard (https://github.com/ericmbarnard)
-*
-*   Source: https://github.com/ericmbarnard/Knockout-Validation
-*   MIT License: http://www.opensource.org/licenses/MIT
+===============================================================================
+    Author:     Eric M. Barnard - @ericmbarnard                                
+    License:    MIT (http://opensource.org/licenses/mit-license.php)           
+                                                                               
+    Description: Validation Library for KnockoutJS                             
+===============================================================================
 */
+
 (function (factory) {
     // Module systems magic dance.
 
@@ -165,13 +167,13 @@
                 ko.utils.extend(configuration, options);
 
                 if (configuration.registerExtenders) {
-                    ko.validation.registerExtenders();
+                    exports.registerExtenders();
                 }
 
                 isInitialized = 1;
             },
             // backwards compatability
-            configure: function (options) { ko.validation.init(options); },
+            configure: function (options) { exports.init(options); },
 
             // resets the config back to its original state
             reset: function () { configuration = $.extend(configuration, defaults); },
@@ -331,10 +333,10 @@
                 }
 
                 //Create an anonymous rule to reference
-                ko.validation.rules[ruleName] = ruleObj;
+                exports.rules[ruleName] = ruleObj;
 
                 //add the anonymous rule to the observable
-                ko.validation.addRule(observable, {
+                exports.addRule(observable, {
                     rule: ruleName,
                     params: ruleObj.params
                 });
@@ -359,14 +361,14 @@
                     //  )};
                     //
                     if (params.message || params.onlyIf) { //if it has a message or condition object, then its an object literal to use
-                        return ko.validation.addRule(observable, {
+                        return exports.addRule(observable, {
                             rule: ruleName,
                             message: params.message,
                             params: utils.isEmptyVal(params.params) ? true : params.params,
                             condition: params.onlyIf
                         });
                     } else {
-                        return ko.validation.addRule(observable, {
+                        return exports.addRule(observable, {
                             rule: ruleName,
                             params: params
                         });
@@ -378,10 +380,10 @@
             // ko.extenders
             registerExtenders: function () { // root extenders optional, use 'validation' extender if would cause conflicts
                 if (configuration.registerExtenders) {
-                    for (var ruleName in ko.validation.rules) {
-                        if (ko.validation.rules.hasOwnProperty(ruleName)) {
+                    for (var ruleName in exports.rules) {
+                        if (exports.rules.hasOwnProperty(ruleName)) {
                             if (!ko.extenders[ruleName]) {
-                                ko.validation.addExtender(ruleName);
+                                exports.addExtender(ruleName);
                             }
                         }
                     }
@@ -401,7 +403,7 @@
             parseInputValidationAttributes: function (element, valueAccessor) {
                 ko.utils.arrayForEach(html5Attributes, function (attr) {
                     if (utils.hasAttribute(element, attr)) {
-                        ko.validation.addRule(valueAccessor(), {
+                        exports.addRule(valueAccessor(), {
                             rule: attr,
                             params: element.getAttribute(attr) || true
                         });
@@ -658,14 +660,14 @@
 
                 // parse html5 input validation attributes, optional feature
                 if (config.parseInputAttributes) {
-                    async(function () { ko.validation.parseInputValidationAttributes(element, valueAccessor) });
+                    async(function () { exports.parseInputValidationAttributes(element, valueAccessor) });
                 }
 
                 // if requested insert message element and apply bindings
                 if (config.insertMessages && utils.isValidatable(valueAccessor())) {
 
                     // insert the <span></span>
-                    var validationMessageElement = ko.validation.insertValidationMessage(element);
+                    var validationMessageElement = exports.insertValidationMessage(element);
 
                     // if we're told to use a template, make sure that gets rendered
                     if (config.messageTemplate) {
@@ -678,7 +680,7 @@
                 // write the html5 attributes if indicated by the config
                 if (config.writeInputAttributes && utils.isValidatable(valueAccessor())) {
 
-                    ko.validation.writeInputValidationAttributes(element, valueAccessor);
+                    exports.writeInputValidationAttributes(element, valueAccessor);
                 }
 
                 // if requested, add binding to decorate element
@@ -817,7 +819,7 @@
             // the 'rule' being passed in here has no name to identify a core Rule,
             // so we add it as an anonymous rule
             // If the developer is wanting to use a core Rule, but use a different message see the 'addExtender' logic for examples
-            ko.validation.addAnonymousRule(observable, rule);
+            exports.addAnonymousRule(observable, rule);
         });
         return observable;
     };
@@ -854,7 +856,7 @@
                 var obs = observable(),
                     ruleContexts = observable.rules();
 
-                ko.validation.validateObservable(observable);
+                exports.validateObservable(observable);
 
                 return true;
             });
@@ -900,7 +902,7 @@
         if (!rule.validator(observable(), ctx.params === undefined ? true : ctx.params)) { // default param is true, eg. required = true
 
             //not valid, so format the error message and stick it in the 'error' variable
-            observable.error = ko.validation.formatMessage(ctx.message || rule.message, ctx.params);
+            observable.error = exports.formatMessage(ctx.message || rule.message, ctx.params);
             observable.__valid__(false);
             return false;
         } else {
@@ -933,7 +935,7 @@
 
             if (!isValid) {
                 //not valid, so format the error message and stick it in the 'error' variable
-                observable.error = ko.validation.formatMessage(msg || ctx.message || rule.message, ctx.params);
+                observable.error = exports.formatMessage(msg || ctx.message || rule.message, ctx.params);
                 observable.__valid__(isValid);
             }
 
@@ -962,7 +964,7 @@
                 continue;
 
             //get the core Rule to use for validation
-            rule = ko.validation.rules[ctx.rule];
+            rule = exports.rules[ctx.rule];
 
             if (rule['async'] || ctx['async']) {
                 //run async validation
@@ -986,10 +988,10 @@
     //#region Validated Observable
 
     ko.validatedObservable = function (initialValue) {
-        if (!ko.validation.utils.isObject(initialValue)) { return ko.observable(initialValue).extend({ validatable: true }); }
+        if (!exports.utils.isObject(initialValue)) { return ko.observable(initialValue).extend({ validatable: true }); }
 
         var obsv = ko.observable(initialValue);
-        obsv.errors = ko.validation.group(initialValue);
+        obsv.errors = exports.group(initialValue);
         obsv.isValid = ko.computed(function () {
             return obsv.errors().length === 0;
         });
@@ -1008,8 +1010,8 @@
 
         //loop the properties in the object and assign the msg to the rule
         for (rule in msgTranslations) {
-            if (ko.validation.rules.hasOwnProperty(rule)) {
-                ko.validation.rules[rule].message = msgTranslations[rule];
+            if (exports.rules.hasOwnProperty(rule)) {
+                exports.rules[rule].message = msgTranslations[rule];
             }
         }
     };
@@ -1033,9 +1035,9 @@
             }
         }
 
-        ko.validation.init();
+        exports.init();
 
-        if (config) { ko.validation.utils.setDomData(node, config); }
+        if (config) { exports.utils.setDomData(node, config); }
 
         ko.applyBindings(viewModel, rootNode);
     };
@@ -1044,7 +1046,7 @@
     var origApplyBindings = ko.applyBindings;
     ko.applyBindings = function (viewModel, rootNode) {
 
-        ko.validation.init();
+        exports.init();
 
         origApplyBindings(viewModel, rootNode);
     };


### PR DESCRIPTION
Simply find/replace "ko.validation" by "exports" except for line 21 of course...

I think it could be interesting to remind in documentation that because of AMD concept, when loaded, validation is NOT available through ko.available property but, in case of RequireJS, via module property given by the loader.

For instance :

require(['knockout', 'knockout.validation', 'app/my-vm', 'domReady!'], function(ko, ko_validation, vm_class) {
    ko_validation.init();
    return ko.applyBindings(new ko.validatedObservable(new vm_class));
});
