### PR TITLE
Adds ability to disable a rule on an observable

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -974,7 +974,11 @@
 
             //get the Rule Context info to give to the core Rule
             ctx = ruleContexts[i];
-
+            
+            // checks if rule is disabled.
+            if (utils.getValue(ctx.enabled) === false || utils.getValue(ctx.disabled) === true)
+                continue;
+                
             // checks an 'onlyIf' condition
             if (ctx.condition && !ctx.condition())
                 continue;


### PR DESCRIPTION
In response to Issue 111 (https://github.com/ericmbarnard/Knockout-Validation/issues/111).
Adds the ability to disable a rule temporarily.
Examples:
Using the following view model...
 ViewModel = { Name = ko.observable().extend({ required:true }); };

Disabling a rule can be accomplished a variety of ways...
 ViewModel.Name.rules()[0].enabled = false;
 ViewModel.Name.rules()[0].disabled = true;
 ko.utils.arrayForEach(ViewModel.Name.rules(), function(rule) {
   if (rule.rule == 'required')
     rule.endabled = false;
 });
