### PR TITLE
Fixing issue with AMD loaders

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -24,6 +24,10 @@
 
     if (typeof (ko) === undefined) { throw 'Knockout is required, please ensure it is loaded before loading this validation plug-in'; }
 
+    if (typeof define === "function" && define["amd"]) {
+        exports = ko.validation = {};
+    }
+
     var defaults = {
         registerExtenders: true,
         messagesOnModified: true,


### PR DESCRIPTION
If you try to load ko validation via Require.js following error arises: "Cannot read property of 'rules' of undefined"
It happens because ko.validation is never set before calling registerExtenders() function. It makes no sense to 
extend "exports" variable because it's just an empty object that nobody uses. The plugin should extend ko object instead. 
Related issue: https://github.com/ericmbarnard/Knockout-Validation/issues/82
