### PR TITLE
ko.validation.group resolves computed values

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -222,7 +222,7 @@
                         ko.utils.arrayForEach(objValues, function (observable) {
 
                             //but not falsy things and not HTML Elements
-                            if (observable && !observable.nodeType && !ko.isComputed(observable))
+                            if (observable && !observable.nodeType && (!ko.isComputed(observable) || observable.rules))
 								traverse(observable, level + 1);
                         });
                     }

--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -222,7 +222,8 @@
                         ko.utils.arrayForEach(objValues, function (observable) {
 
                             //but not falsy things and not HTML Elements
-                            if (observable && !observable.nodeType) traverse(observable, level + 1);
+                            if (observable && !observable.nodeType && !ko.isComputed(observable))
+								traverse(observable, level + 1);
                         });
                     }
                 };

--- a/Tests/validation-tests.js
+++ b/Tests/validation-tests.js
@@ -1039,7 +1039,7 @@ test('Issue #37 - Toggle ShowAllMessages', function () {
     ok(!vm.three.two.one.isModified(), "Level 3 is not modified");
 });
 
-test('Group does not resolve computed values', function () {
+test('Group does not resolve deferred computed values', function () {
 	var vm = {
 		Value: ko.observable('no')
 	};
@@ -1050,9 +1050,28 @@ test('Group does not resolve computed values', function () {
 		deferEvaluation: true
 	});
 	
-	equal(vm.Value(), 'no');
+	equal(vm.Value(), 'no', 'Not resolved');
 	ko.validation.group(vm);
-	equal(vm.Value(), 'no');
+	equal(vm.Value(), 'no', 'Still not resolved');
+	equal(vm.errors().length, 0, 'No errors');
+});
+
+test('Group does resolve deferred computed values that have validation', function () {
+	var vm = {
+		Value: ko.observable('no')
+	};
+	vm.Test = ko.computed({
+		read: function () {
+			vm.Value('yes');
+		},
+		deferEvaluation: true
+	});
+	
+	equal(vm.Value(), 'no', 'Not resolved');
+	vm.Test.extend({ required: true });
+	ko.validation.group(vm);
+	equal(vm.Value(), 'yes', 'Resolved');
+	equal(vm.errors().length, 1, 'Error notification');
 });
 //#endregion
 

--- a/Tests/validation-tests.js
+++ b/Tests/validation-tests.js
@@ -1038,6 +1038,22 @@ test('Issue #37 - Toggle ShowAllMessages', function () {
     ok(!vm.two.one.isModified(), "Level 2 is not modified");
     ok(!vm.three.two.one.isModified(), "Level 3 is not modified");
 });
+
+test('Group does not resolve computed values', function () {
+	var vm = {
+		Value: ko.observable('no')
+	};
+	vm.Test = ko.computed({
+		read: function () {
+			vm.Value('yes');
+		},
+		deferEvaluation: true
+	});
+	
+	equal(vm.Value(), 'no');
+	ko.validation.group(vm);
+	equal(vm.Value(), 'no');
+});
 //#endregion
 
 //#region Conditional Validation


### PR DESCRIPTION
I had an issue with one of my computed observables being resolved on creation, even though deferEvaluation was set to true.

Example: When the computed is resolved, it sets Value to "yes":
http://jsfiddle.net/IanYates83/jyVAL/3/
Note that "deferEvaluation" is true, but the computed is still resolved. Commenting out the ko.validation.group line leaves Value as "no".

I eventually traced the issue to validation.group resolving the unwrapping  the "observable", regardless of the source.
The fix I propose is to explicitly not traverse computed observables.

Same example, with fix in place:
http://jsfiddle.net/IanYates83/jyVAL/

I'm hoping that this change doesn't change any functionality others rely on. All tests work with this code change, and this bug explicitly states that "validating computed observables is probably something we don't want to do going forward": https://github.com/ericmbarnard/Knockout-Validation/issues/86