### PR TITLE
Config to disable setting errors as 'title'

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -31,6 +31,7 @@
     var defaults = {
         registerExtenders: true,
         messagesOnModified: true,
+		errorsAsTitle: true,  			// enables/disables showing of errors as title attribute of the target element.
         errorsAsTitleOnModified: false, // shows the error when hovering the input field (decorateElement must be true)
         messageTemplate: null,
         insertMessages: true,           // automatically inserts validation messages as <span></span>
@@ -781,7 +782,9 @@
 
             //add or remove class on the element;
             ko.bindingHandlers.css.update(element, cssSettingsAccessor);
-
+			
+			if (!config.errorsAsTitle) return;
+			
             var origTitle = element.getAttribute('data-orig-title');
             var elementTitle = element.title;
             var titleIsErrorMsg = element.getAttribute('data-orig-title') == "true"

--- a/Tests/validation-ui-tests.js
+++ b/Tests/validation-ui-tests.js
@@ -177,6 +177,40 @@ test('Original titles are restored with multiple validators, too', function () {
 
 });
 
+test('Showing Errors As Titles is disabled sucessfully', function () {
+
+    addTestHtml('<input id="myTestInput" data-bind="value: firstName" type="text" />');
+
+    var vm = {
+        firstName: ko.observable('').extend({ required: true })
+    };
+
+    // make sure the options are ok.
+    ko.validation.init({
+        errorsAsTitleOnModified: true,
+        decorateElement: true,
+		errorsAsTitle: false
+    }, true);
+
+    applyTestBindings(vm);
+
+    var $testInput = $('#myTestInput');
+
+    $testInput.val("a"); //set it 
+    $testInput.change(); //trigger change event
+
+    $testInput.val(""); //set it 
+    $testInput.change(); //trigger change event
+
+    var isValid = vm.firstName.isValid();
+
+    ok(!isValid, 'First Name is NOT Valid');
+    console.log($testInput)
+    var msg = $testInput.attr('title');
+
+    notEqual(msg, 'This field is required.', msg);
+});
+
 //#endregion
 
 //#region Validation Option Tests


### PR DESCRIPTION
Added config 'errorsAsTitle' to disable setting element 'title' with error description.,
by default this is true.

Fix for #168
