### PR TITLE
Descriptive error for undefined validationElement

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -776,6 +776,10 @@
                 msg = null,
                 isModified = false,
                 isValid = false;
+                
+            if (typeof obsv === 'undefined') {
+                throw 'Cannot bind validationElement to undefined value. data-bind expression: ' + element.getAttribute('data-bind');
+            }
 
             obsv.extend({ validatable: true });
 


### PR DESCRIPTION
This error handling will give a more descriptive error if the validationElement binding value is referring to a variable that does not exists (probably a typo).

The native js error (chrome) is not so informative:

```
Uncaught TypeError: Cannot call method 'extend' of undefined
```
