### PR TITLE
Erroneous check in extender for 'unique' validation rule

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -660,7 +660,7 @@
                 if (val === (options.valueAccessor ? options.valueAccessor(item) : item)) counter++;
             });
             // if value is external even 1 same value in collection means the value is not unique
-            return counter < (external !== undefined && val !== external ? 1 : 2);
+            return counter < (external !== undefined && false !== external ? 1 : 2);
         },
         message: 'Please make sure the value is unique.'
     };


### PR DESCRIPTION
The check for val !== external in the return statement should be false !== external because otherwise when val === true and external === true, this validator would not work.
