### PR TITLE
Number validator: allow numbers starting with a point

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -490,7 +490,7 @@
 
     ko.validation.rules['number'] = {
         validator: function (value, validate) {
-            return utils.isEmptyVal(value) || (validate && /^-?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?$/.test(value));
+            return utils.isEmptyVal(value) || (validate && /^-?(?:\d+|\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/.test(value));
         },
         message: 'Please enter a number'
     };

--- a/Tests/validation-tests.js
+++ b/Tests/validation-tests.js
@@ -387,6 +387,15 @@ test('Object is Valid and isValid returns True', function () {
     ok(testObj.isValid(), 'testObj is Valid');
 });
 
+test('Number is Valid (starting with point) and isValid returns True', function () {
+    var testObj = ko.observable('').extend({ number: true });
+
+    testObj(".15");
+
+    equal(testObj(), ".15", 'observable still works');
+    ok(testObj.isValid(), 'testObj is Valid');
+});
+
 test('Object is NOT Valid and isValid returns False', function () {
     var testObj = ko.observable('').extend({ number: true });
 


### PR DESCRIPTION
It is very common that people write numbers starting with a point when 0 is on the left side. For example '.15' instead of '0.15'. Also, JavaScript is able to parse strings like '.15' to numbers without problems.

This small change allows those numbers to be valid.
