### PR TITLE
Fixed the fiddle link in jsFiddle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ myViewModel().property2(9);
 console.log(myViewModel.isValid()); //true
 
 ```
-see more examples on the Fiddle: http://jsfiddle.net/ericbarnard/KHFn8/
+see more examples on the Fiddle: http://jsfiddle.net/CWbyW/1/
 
 ##Native Validation Rules
 **Required**:


### PR DESCRIPTION
The reference to knockout on github had expired.  Changed it to the current download link from the knockoutjs site.
