### PR TITLE
Fix for not honoring messagesOnModified set to false when deciding if element should be decorated with css.

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -826,7 +826,7 @@
             var cssSettingsAccessor = function () {
                 var css = {};
 
-                var shouldShow = (isModified ? !isValid : false);
+                var shouldShow = !config.messagesOnModified ? !isValid : isModified ? !isValid : false;
 
                 if (!config.decorateElement) { shouldShow = false; }
 


### PR DESCRIPTION
Fix for #211. If messagesOnModified in config is set to false, validationElement just ignores the fact that in the case of being invalid it should be decorated with css.
