### PR TITLE
Untabify those few lines with tabs.

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -840,7 +840,7 @@
             ko.bindingHandlers.css.update(element, cssSettingsAccessor);
             if (!config.errorsAsTitle) { return; }
             
-			var origTitle = utils.getAttribute(element, 'data-orig-title'),
+            var origTitle = utils.getAttribute(element, 'data-orig-title'),
                 elementTitle = element.title,
                 titleIsErrorMsg = utils.getAttribute(element, 'data-orig-title') === "true";
 
@@ -947,16 +947,16 @@
                 return observable.__valid__();
             });
 
-			//manually set error state
+            //manually set error state
             observable.setError = function (error) {
-				observable.error(error);
-            	observable.__valid__(false);
+                observable.error(error);
+                observable.__valid__(false);
             };
 
-			//manually clear error state
+            //manually clear error state
             observable.clearError = function () {
-            	observable.error(null);
-				observable.__valid__(true);
+                observable.error(null);
+                observable.__valid__(true);
             }
 
             //subscribe to changes in the observable


### PR DESCRIPTION
Went in to fix a bug whereby "ruleObj['message'] = 'Error';" was mis-spelt as rule_s_Obj[ etc. Accepted vs2012's prompt to fix mixed tabs and spaces by untabifying.
