### PR TITLE
isValidatable Bulletproofing

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -117,6 +117,7 @@
                 return element.setAttribute(attr, value);
             },
             isValidatable: function (o) {
+            	if (o === undefined) return false;
                 return o && o.rules && o.isValid && o.isModified;
             },
             insertAfter: function (node, newNode) {


### PR DESCRIPTION
Inside of the isValidatable function I added a line to return false if the "o" argument is undefined. The value of undefined was coming in for a few of my scenarios. It was honestly a problem somewhere else but it seemed an appropriate bulletproofing line for a library. If you're not opposed to this I'd appreciate having it in future versions. I'm thinking it's harmless and will add value.
