### PR TITLE
Step validation floating point errors fix

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -610,7 +610,9 @@
 
             // in order to handle steps of .1 & .01 etc.. Modulus won't work
             // if the value is a decimal, so we have to correct for that
-            return utils.isEmptyVal(val) || (val * 100) % (step * 100) === 0;
+            if (utils.isEmptyVal(val) || step == 'any') return true;
+            var dif = (val * 100) % (step * 100);
+            return Math.abs(dif) < 0.00001 || Math.abs(1 - dif) < 0.00001;
         },
         message: 'The value must increment by {0}'
     };

--- a/Tests/validation-tests.js
+++ b/Tests/validation-tests.js
@@ -377,6 +377,17 @@ test('Issue 74 - Object is NOT Valid with a step of 0.1 and isValid returns Fals
     equal(testObj(), 5.15, 'observable still works');
     equal(testObj.isValid(), false, 'testObj is not valid');
 });
+
+test('Step validation fix regression check', function() {
+    var testObj = ko.observable(33.34).extend({ step: 0.01});
+    ok(!testObj.error(), 'step validation not triggered');
+});
+
+test('Step validation any value is allowed', function() {
+    var testObj = ko.observable(33.34).extend({ step: 'any' });
+    ok(!testObj.error(), '"any" value for step is allowed');
+});
+
 //#endregion
 
 //#region Email Validation


### PR DESCRIPTION
Step validation fails for valid changes under certain conditions, due to
floating point rounding errors. For instance, 33.34 \* 100 will yield a
value very close to 3334, but slightly above it and will never equal
3334 exactly. This fixes this by making less strict checks
(modulus should be within a certain tolerance of zero, and the tolerance
could be increased if for some crazy reason someone wanted more
precision).

This also allows the step parameter to have the 'any' value, which is
valid according to the HTML5 spec.
