### PR TITLE
Add 'appendMessageToParent' configuration option.

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -57,6 +57,7 @@
         errorsAsTitleOnModified: false, // shows the error when hovering the input field (decorateElement must be true)
         messageTemplate: null,
         insertMessages: true,           // automatically inserts validation messages as <span></span>
+        appendMessageToParent: false,   // if true, inserted messages are appended to the parent of the element
         parseInputAttributes: false,    // parses the HTML5 validation attribute from a form element and adds that to the object
         writeInputAttributes: false,    // adds HTML5 input validation attributes to form elements that ko observable's are bound to
         decorateElement: false,         // false to keep backward compatibility
@@ -121,6 +122,9 @@
             },
             insertAfter: function (node, newNode) {
                 node.parentNode.insertBefore(newNode, node.nextSibling);
+            },
+            appendToParent: function (node, newNode) {
+                node.parentNode.appendChild(newNode);
             },
             newId: function () {
                 return seedId += 1;
@@ -439,8 +443,13 @@
             //creates a span next to the @element with the specified error class
             insertValidationMessage: function (element) {
                 var span = document.createElement('SPAN');
-                span.className = utils.getConfigOptions(element).errorMessageClass;
-                utils.insertAfter(element, span);
+                var config = utils.getConfigOptions(element);
+                span.className = config.errorMessageClass;
+                if (config.appendMessageToParent) {
+                  utils.appendToParent(element, span);
+                } else {
+                  utils.insertAfter(element, span);
+                }
                 return span;
             },
 

--- a/Tests/validation-ui-tests.js
+++ b/Tests/validation-ui-tests.js
@@ -90,6 +90,36 @@ test('Inserting Messages Works', function () {
     equal(msg, 'This field is required.', msg);
 });
 
+test('Messages can be appended to the parent of the input', function () {
+
+  addTestHtml('<div id="parent" data-bind="validationOptions: { appendMessageToParent: true }">' +
+      '<input id="testInputWithSibling" data-bind="value: firstName" type="text" />' +
+      '<span id="inputSibling">First input sibling</span>' +
+    '</div>');
+
+
+  var vm = {
+    firstName: ko.observable('').extend({ required: true })
+  };
+
+  applyTestBindings(vm);
+
+  var $testInput = $('#testInputWithSibling');
+  $testInput.val('a');
+  $testInput.change();
+  $testInput.val('');
+  $testInput.change();
+
+  var isValid = vm.firstName.isValid();
+  ok(!isValid, 'First Name is NOT Valid');
+
+  var firstSiblingMsg = $testInput.siblings().first().text();
+  equal(firstSiblingMsg, 'First input sibling', firstSiblingMsg);
+
+  var lastSiblingMsg = $testInput.siblings().last().text();
+  equal(lastSiblingMsg, 'This field is required.', lastSiblingMsg);
+});
+
 //#endregion
 
 //#region Showing errors as titles


### PR DESCRIPTION
Hi,

Thank you very much for the development of Knockout-Validation, it's really great!
I am submitting this pull request because in our project the inputs that we want to validate may have a small icon by their side, and we want the validation messages to be displayed after those icons.
Thinking about that, I added a configuration that allows developers to configure Knockout-Validation so that validation messages can be appended to the parent node of the input element, instead of having them inserted after the input.

Please let me know if you have any questions, comments or concerns with this approach.
I think this can be really useful, and I will be more than happy to make adjustments as you deem necessary.

Thank a bunch!

Luiz
