### PR TITLE
Html5InputAttribute test now waits for async validators to load

### DIFF
--- a/Tests/validation-ui-tests.js
+++ b/Tests/validation-ui-tests.js
@@ -604,7 +604,29 @@ test("HTML5 Input types", function () {
     applyTestBindings(vm);
     stop();
 
-    setTimeout(function() {
+    // The validators for the HTML5 Input types are applied asynchronously,
+    // so we need to wait until the validators have been applied.  This is
+    // done by checking to make sure that the rule has been added to the rules
+    // list of each observable.
+    var intervalsWaited = 0;
+    var intervalId = setInterval(function() {
+        if (intervalsWaited++ > 1000) {
+            clearInterval(intervalId);
+            ok(false, 'Async HTML5 Input validators did not apply within a reasonable amount of time');
+            start();
+        }
+        var validatorsReady =
+            vm.invalidEmail.rules().length > 0 &&
+            vm.invalidDate.rules().length > 0 &&
+            vm.invalidNumber.rules().length > 0;
+        if (validatorsReady) 
+            runAssertions();
+    }, 1);
+    
+    function runAssertions()
+    {
+        clearInterval(intervalId);
+        
         var $emailInput = $('#emailInput');
         var emailInput = $emailInput.get(0);
         var $dateInput = $('#dateInput');
@@ -616,8 +638,8 @@ test("HTML5 Input types", function () {
         ok(!vm.invalidDate.isValid(), 'Expected date to be considered as invalid.');
         ok(!vm.invalidNumber.isValid(), 'Expected date to be considered as invalid.');
 
-      start();
-    }, 1 );
+        start();
+    }    
 });
 
 


### PR DESCRIPTION
When running the tests on IE10, one of the tests related to HTML5 input attributes would fail strangely.  Sometimes 2 assertions in the test would fail, and sometimes all would fail.  In looking into this a little more closely, I saw that the validation for the HTML5 input attributes were applied asynchronously, which resulted in the test assertions running before the validation had been applied to the observables.

This change forces the test to wait until the validation has been applied to the observables before the assertions are run.  If it sits there for too long, it will give up and fail the test so that the test doesn't hang forever.
