### PR TITLE
Handle params which may be undefined.

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -407,7 +407,7 @@
                     //      }
                     //  )};
                     //
-                    if (params.message || params.onlyIf) { //if it has a message or condition object, then its an object literal to use
+                    if (params && (params.message || params.onlyIf)) { //if it has a message or condition object, then its an object literal to use
                         return exports.addRule(observable, {
                             rule: ruleName,
                             message: params.message,


### PR DESCRIPTION
Sometimes params can be undefined. This ensures this event doesn't cause an error.
