### PR TITLE
Add the ability to see which rule object has errored

### DIFF
--- a/Src/knockout.validation.js
+++ b/Src/knockout.validation.js
@@ -1074,12 +1074,14 @@
             } else {
                 //run normal sync validation
                 if (!validateSync(observable, rule, ctx)) {
-                    observable.errorRule(null); // Clear the errored rule
                     return false; //break out of the loop
                 }
             }
         }
         //finally if we got this far, make the observable valid again!
+        if (observable.errorRule) {
+            observable.errorRule(null); // Clear the errored rule
+        }
         observable.error(null);
         observable.__valid__(true);
         return true;


### PR DESCRIPTION
Allow users to lookup the real error rule by exposing it. This can let a user perform different actions depending on other parameters of the error (eg you can make them do a popup if they serious/fatal as opposed to simpler notification if not fatal etc...)
