### PR TITLE
Min and max validation now use type attribute to determine behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,39 @@ Learn more about Custom Rules on the [WIKI](https://github.com/Knockout-Contrib/
 
 ##HTML5 Validation Attributes
 
-Required: `<input type="text" data-bind="value: myProp" required />`
+**Required**: 
 
-Min: `<input type="text" data-bind="value: myProp" min="2" />`
+```html
+<input type="text" data-bind="value: myProp" required />
+```
 
-Max: `<input type="text" data-bind="value: myProp" max="99" />`
+**Min**:
 
-Pattern: `<input type="text" data-bind="value: myProp" pattern="^[a-z0-9].*" />`
+```html
+<input type="number" data-bind="value: myProp" min="2" />
+<input type="week" data-bind="value:myWeek" min="2012-W03" />
+<input type="month" data-bind="value:myMonth" min="2012-08" />
+```
 
-Step: `<input type="text" data-bind="value: myProp" step="3" />`
+**Max**: 
 
+```html
+<input type="number" data-bind="value: myProp" max="99" />
+<input type="week" data-bind="value:myWeek" max="2010-W15" />
+<input type="month" data-bind="value:myMonth" min="2012-08" />
+```
+
+**Pattern**: 
+
+```html
+<input type="text" data-bind="value: myProp" pattern="^[a-z0-9].*" />
+```
+
+**Step**: 
+
+```html
+<input type="text" data-bind="value: myProp" step="3" />
+```
 **Special Note, the 'MinLength' attribute was removed until the HTML5 spec fully supports it**
 
 ##Knockout Bindings

--- a/Src/api.js
+++ b/Src/api.js
@@ -280,9 +280,27 @@
 		parseInputValidationAttributes: function (element, valueAccessor) {
 			ko.utils.arrayForEach(ko.validation.configuration.html5Attributes, function (attr) {
 				if (utils.hasAttribute(element, attr)) {
+
+                    var params = element.getAttribute(attr) || true;
+
+                    if (attr === 'min' || attr === 'max')
+                    {
+                        // If we're validating based on the min and max attributes, we'll
+                        // need to know what the 'type' attribute is set to
+                        var typeAttr = element.getAttribute('type');
+                        if (typeof typeAttr === "undefined" || !typeAttr)
+                        {
+                            // From http://www.w3.org/TR/html-markup/input:
+                            //   An input element with no type attribute specified represents the 
+                            //   same thing as an input element with its type attribute set to "text".
+                            typeAttr = "text"; 
+                        }                            
+                        params = {typeAttr: typeAttr, value: params}; 
+                    }
+                
 					ko.validation.addRule(valueAccessor(), {
 						rule: attr,
-						params: element.getAttribute(attr) || true
+						params: params
 					});
 				}
 			});

--- a/Tests/validation-ui-tests.js
+++ b/Tests/validation-ui-tests.js
@@ -615,6 +615,17 @@ test("Issue #80 - HTML5 attributes - pattern", function () {
     strictEqual(vm.testObj(), 'something', 'Observable still works');
 });
 
+module('HTML5 UI Tests', {
+    setup: function () {
+
+    },
+    teardown: function () {
+        ko.cleanNode($('#testContainer')[0]);
+        $('#testContainer').empty();
+        ko.validation.reset();
+    }
+});
+
 test("HTML5 Input types", function () {
 
     var vm = {
@@ -675,6 +686,526 @@ test("HTML5 Input types", function () {
     }
 });
 
+test('min Attribute of 20 should fail for value of 8', function () {
 
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="number" min="20" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber(8); // should fail the max rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 20 should fail for value of "8"', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="text" min="20" data-bind="value:someNumber", validationElement: someNumber" />');
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("8"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 20 should fail for value of "8" with text type', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="text" min="20" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("8"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 20 should pass for value of 110', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="number" min="20" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true,
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber(110); // should validate the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+        
+        start();
+    }, 1);
+    
+});
+
+test('MIN Attribute of 20 should pass for value of "110"', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="number" min="20" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true,
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("110"); // should validate the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+        
+        start();
+    }, 1);
+    
+});
+
+test('max Attribute of 30 should fail for value of 100', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="number" max="30" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber(100); // should fail the max rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('max Attribute of 30 should fail for value of "100"', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="text" max="30" data-bind="value:someNumber", validationElement: someNumber" />');
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("100"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('max Attribute of 30 should fail for value of "100" with text type', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="text" max="30" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber(100); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('max Attribute of 30 should pass for value of 5', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="number" max="30" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true,
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber(5); // should validate the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+        
+        start();
+    }, 1);
+    
+});
+
+test('max Attribute of 30 should pass for value of "5"', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="number" max="30" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true,
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("5"); // should validate the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+        
+        start();
+    }, 1);
+    
+});
+
+test('max Attribute of 2010-09 should fail for value of 2011-03', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="month" max="2010-09" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2011-03"); // should fail the max rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('max Attribute of 2010-09 should succeed for value of 2010-08', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="month" max="2010-09" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2010-08"); // should succeed the max rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 2010-09 should fail for value of 2010-08', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="month" min="2010-09" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2010-08"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 2012-05 should fail for value of 2011-01', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="month" min="2012-05" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2011-01"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 2012-03 should succeed for value of 2013-01', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="month" min="2012-03" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2013-01"); // should succeed the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('max Attribute of 2010-W09 should fail for value of 2011-W03', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="week" max="2010-W09" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2011-W03"); // should fail the max rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is not valid");
+
+        start();
+    }, 1);
+});
+
+test('max Attribute of 2010-W09 should succeed for value of 2010-W08', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="week" max="2010-W09" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2010-W08"); // should succeed the max rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 2010-W09 should fail for value of 2010-W08', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="Week" min="2010-W09" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2010-W08"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 2012-W05 should fail for value of 2011-W01', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="week" min="2012-W05" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2011-W01"); // should fail the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(!vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
+
+test('min Attribute of 2012-W03 should succeed for value of 2013-W01', function () {
+
+    var vm = {
+        someNumber: ko.validatedObservable()
+    };
+    
+    addTestHtml('<input id="myTestInput" type="week" min="2012-W03" data-bind="value:someNumber", validationElement: someNumber" />');
+
+    ko.validation.init({
+        parseInputAttributes: true
+    }, true);
+    applyTestBindings(vm);
+    stop();
+    
+    setTimeout(function() {
+        vm.someNumber("2013-W01"); // should succeed the min rule
+        
+        var el = $('#myTestInput');
+
+        ok(el, 'found element');
+        ok(vm.someNumber.isValid(), "Object is valid");
+
+        start();
+    }, 1);
+});
 
 //#endregion


### PR DESCRIPTION
When used as HTML5 attributes, min and max were comparing as strings.  So an element of `<input min="10" data-bind="value:myNumber">` would validate successfully for a value of 5, because the string "5" is greater than the string "10".  This was understandably causing some problems.

This update changes the min and max validators so that they pay attention to the type attribute.  For example, the element `<input type="month" min="2010-03" data-bind="value:myMonth">` will use appropriate logic to ensure that the entered date is entered as a month and is March 2010 or later.  And an element of `<input type="number" min="10" data-bind="value:myNumber">` will fail validation if a value of 5 is entered.

Tests and Documentation updates included.

This was originally in PR https://github.com/Knockout-Contrib/Knockout-Validation/pull/324, but I decided to create a new PR after the Knockout-Validation folder restructuring so that this could be a single, clean commit.

Thanks to @stevegreatrex for help in reviewing this feature.
