### PR TITLE
support validation for selectedOptions handler

### DIFF
--- a/Src/bindingHandlers.js
+++ b/Src/bindingHandlers.js
@@ -45,6 +45,7 @@ ko.bindingHandlers['validationCore'] = (function () {
 // override for KO's default 'value' and 'checked' bindings
 ko.validation.makeBindingHandlerValidatable("value");
 ko.validation.makeBindingHandlerValidatable("checked");
+ko.validation.makeBindingHandlerValidatable("selectedOptions");
 
 
 ko.bindingHandlers['validationMessage'] = { // individual error message, if modified or post binding


### PR DESCRIPTION
Support for validating through the [selectedOptions](http://knockoutjs.com/documentation/selectedOptions-binding.html) handler. 

I have not done extensive testing, but it appears to work for me.
