### PR TITLE
Update to handle small steps - ie: 0.0000001

### DIFF
--- a/Dist/knockout.validation.js
+++ b/Dist/knockout.validation.js
@@ -803,12 +803,17 @@ kv.rules['pattern'] = {
 
 kv.rules['step'] = {
 	validator: function (val, step) {
-
+		var min_diff = 0.000000001;
+	
+	
 		// in order to handle steps of .1 & .01 etc.. Modulus won't work
 		// if the value is a decimal, so we have to correct for that
 		if (kv.utils.isEmptyVal(val) || step === 'any') { return true; }
-		var dif = (val * 100) % (step * 100);
-		return Math.abs(dif) < 0.00001 || Math.abs(1 - dif) < 0.00001;
+		var valInt = val / step;
+		var stepInt = step * ( 1 / step);
+		var diff = valInt % stepInt;
+	
+		return Math.abs(diff) < min_diff || Math.abs(1 - diff) < min_diff;
 	},
 	message: 'The value must increment by {0}'
 };

--- a/Tests/rules-tests.js
+++ b/Tests/rules-tests.js
@@ -628,6 +628,31 @@ test('Object is NOT Valid and step is observable and isValid returns False', fun
 	equal(testObj.isValid(), false, 'testObj is not valid');
 });
 
+test('Object is NOT Valid with a step of 0.00000003 and isValid returns False', function () {
+	var testObj = ko.observable('')
+                    .extend({ step: 0.00000003 });
+
+	testObj(0.00001115);
+
+	equal(testObj(), 0.00001115, 'observable still works');
+	equal(testObj.isValid(), false, 'testObj is not Valid');
+});
+
+
+
+
+test('Object is Valid with a step of 0.00000001 and isValid returns True', function () {
+	var testObj = ko.observable('')
+                    .extend({ step: 0.00000002 });
+
+	testObj(0.00001116);
+
+	equal(testObj(), 0.00001116, 'observable still works');
+	ok(testObj.isValid(), 'testObj is Valid');
+});
+
+
+
 //#endregion
 
 //#region Email Validation


### PR DESCRIPTION
I was having issues with very, very small step increments.  Updated so that the code now will handle small steps by multiplying by that step amount to convert to a handleable number.

Example: 
    var testObj = ko.observable('')
                    .extend({ step: 0.00000003 });

```
testObj(0.00001115);
    testObj.isValid() != true;
```
