### PR TITLE
Do not change original data by kv.group

### DIFF
--- a/Src/api.js
+++ b/Src/api.js
@@ -174,11 +174,7 @@
 				});
 			};
 
-			obj.errors = result;
-			obj.isValid = function () {
-				return obj.errors().length === 0;
-			};
-			obj.isAnyMessageShown = function () {
+			result.isAnyMessageShown = function () {
 				var invalidAndModifiedPresent = false;
 
 				// ensure we have latest changes

--- a/Src/ko.extensions.js
+++ b/Src/ko.extensions.js
@@ -36,7 +36,7 @@ ko.validatedObservable = function (initialValue, options) {
 
 	var obsv = ko.observable(initialValue);
 	obsv.errors = ko.validation.group(initialValue, options);
-	obsv.isValid = ko.observable(initialValue.isValid());
+	obsv.isValid = ko.observable(obsv.errors().length === 0);
 
 
 	if (ko.isObservable(obsv.errors)) {

--- a/Tests/api-tests.js
+++ b/Tests/api-tests.js
@@ -274,7 +274,7 @@ test('validatedObservable does not show error message when not modified', functi
 	});
 
 	ok(obj(), 'observable works');
-	ok(!obj().isAnyMessageShown(), 'validation error message is hidden');
+	ok(!obj.errors.isAnyMessageShown(), 'validation error message is hidden');
 
 });
 
@@ -288,7 +288,7 @@ test('validatedObservable does not show error message when modified but correct'
 	obj().testObj2('a');
 
 	ok(obj(), 'observable works');
-	ok(!obj().isAnyMessageShown(), 'validation error message is hidden');
+	ok(!obj.errors.isAnyMessageShown(), 'validation error message is hidden');
 
 });
 
@@ -301,7 +301,7 @@ test('validatedObservable show error message when at least one invalid and modif
 	obj().testObj.isModified(true);
 
 	ok(obj(), 'observable works');
-	ok(obj().isAnyMessageShown(), 'validation error message is shown');
+	ok(obj.errors.isAnyMessageShown(), 'validation error message is shown');
 
 });
 


### PR DESCRIPTION
Do not patch isValid, errors and isAnyMessageShown to original given data

``` javascript
ko.validation.init();

var data = {
    first_name: ko.observable('John').extend({required: true}),
    last_name: ko.observable('Doe').extend({required: true}),
    email: ko.observable('john.doe(at)example.com').extend({required: true, email: true}),
};
var validatedObservable = ko.validatedObservable(data);
var normalObservable = ko.observable(data);

validatedObservable.isValid();
validatedObservable.errors();
validatedObservable.errors.showAllMessages();
validatedObservable.errors.isAnyMessageShown();
ko.toJSON(validatedObservable()); // {first_name: "John", last_name: "Doe", email: "john.doe(at)example.com"}
console.log(ko.toJSON(validatedObservable()) === ko.toJSON(data)); // true
console.log(ko.toJSON(normalObservable()) === ko.toJSON(data)); // true
console.log(ko.toJSON(validatedObservable()) === ko.toJSON(normalObservable())); // true
```

removed

``` javascript
validatedObservable().isValid();
validatedObservable().errors();
validatedObservable().isAnyMessageShown();
ko.toJSON(validatedObservable()); // {"first_name":"John","last_name":"Doe","email":"john.doe(at)example.com","errors":["Please enter a proper email address."]}
```
