### PR TITLE
Fix #528 - use peerDependencies for npm package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A KnockoutJS Plugin for model and property validation",
   "main": "dist/knockout.validation.js",
   "files": ["dist", "localization", "CONTRIBUTING.md"],
-  "dependencies": {
+  "peerDependencies": {
     "knockout": ">=2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Knockout-Validation may not decorate the correct instance of Knockout
when used with node.js due to improper way of specifying dependencies.