### PR TITLE
Make "isModified(true) on change" behavior optional

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -21,6 +21,7 @@ var defaults = {
 		live: false		    //react to changes to observableArrays if observable === true
 	},
 	validate: {
+		setModifiedOnChange: true, // enables setting `isModified(true)` when observable changes
 		// throttle: 10
 	}
 };

--- a/test/api-tests.js
+++ b/test/api-tests.js
@@ -743,6 +743,46 @@ QUnit.test('validatedObservable works when changing from undefined to object', f
 	assert.equal(testObj.errors()[0], 'This field is required.', 'message is correct');
 });
 
+QUnit.test('validatedObservable by default is automatically isModified whenever it\'s value changes', function (assert) {
+	var testObj = ko.observable().extend({ validatable: true });
+
+	assert.strictEqual(testObj.isModified(), false, 'observable is not modified');
+
+	testObj(1);
+
+	assert.strictEqual(testObj.isModified(), true, 'observable is modified');
+});
+
+QUnit.test('validatedObservable isModified(true) on change can be disabled using global configuration', function (assert) {
+	ko.validation.init({
+		validate: {
+			setModifiedOnChange: false
+		}
+	}, true);
+
+	var testObj = ko.observable().extend({ validatable: true });
+
+	assert.strictEqual(testObj.isModified(), false, 'observable is not modified');
+
+	testObj(1);
+
+	assert.strictEqual(testObj.isModified(), false, 'observable is not modified');
+});
+
+QUnit.test('validatedObservable isModified(true) on change can be disabled using local configuration', function (assert) {
+	var testObj = ko.observable().extend({
+		validatable: {
+			setModifiedOnChange: false
+		}
+	});
+
+	assert.strictEqual(testObj.isModified(), false, 'observable is not modified');
+
+	testObj(1);
+
+	assert.strictEqual(testObj.isModified(), false, 'observable is not modified');
+});
+
 //#endregion
 
 //#region setRules Tests


### PR DESCRIPTION
One may want validated observables to say not `isModified()` in following cases:
* Observable value changed programmatically without user interaction
* Deserialization (view model state loaded from JSON, no need to display validation messages)
* `value` or other binding updates observables too eagerly (for instance `valueUpdate: 'keyup'`) but you don't want to messages to be displayed