### PR TITLE
Make it possible to use an arbitrary object as validation message

### DIFF
--- a/dist/knockout.validation.js
+++ b/dist/knockout.validation.js
@@ -436,6 +436,9 @@ kv.configuration = configuration;
 		},
 
 		formatMessage: function (message, params, observable) {
+			if (typeof message === 'object') {
+				return message;
+			}
 			if (utils.isObject(params) && params.typeAttr) {
 				params = params.value;
 			}

--- a/src/api.js
+++ b/src/api.js
@@ -238,6 +238,9 @@
 		},
 
 		formatMessage: function (message, params, observable) {
+			if (typeof message === 'object') {
+				return message;
+			}
 			if (utils.isObject(params) && params.typeAttr) {
 				params = params.value;
 			}

--- a/test/api-tests.js
+++ b/test/api-tests.js
@@ -977,6 +977,28 @@ QUnit.test('formatMessage may use multiple replacements', function(assert) {
 	assert.equal(result, 'Value must be between 1 and 5.');
 });
 
+QUnit.test('formatMessage allows arbitrary object as message', function(assert) {
+	var params = null,
+		message = { custom: 'object' },
+		obsv = ko.observable();
+
+	var result = ko.validation.formatMessage(message, params, obsv);
+	assert.strictEqual(result, message, '`formatMessage` must return message object intact');
+});
+
+QUnit.test('arbitrary object can be used as a message', function(assert) {
+	var message = { custom: 'object' },
+		obsv = ko.observable().extend({
+		validation: {
+			validator: function () { return false; },
+			message: message
+		}
+	});
+
+	var result = obsv.error();
+	assert.strictEqual(result, message);
+});
+
 QUnit.test('Issue #547 - formatMessage fails when params is 0', function(assert) {
     var params = 0,
         message = 'Please enter a value greater than or equal to {0}.',


### PR DESCRIPTION
Useful if you want to supply more information about the error other then just text.
My use case is a custom `validationMessage`-like binding with message appearance depending on it's kind.