### PR TITLE
sv-SE.js maxLength threshold is inclusive

### DIFF
--- a/localization/sv-SE.js
+++ b/localization/sv-SE.js
@@ -23,7 +23,7 @@
 		min: 'Fyll i ett värde som är större än eller lika med {0}',
 		max: 'Fyll i ett värde som är mindre än eller lika med {0}',
 		minLength: 'Fyll i minst {0} tecken',
-		maxLength: 'Fyll i färre än {0} tecken',
+		maxLength: 'Fyll inte i fler än {0} tecken',
 		pattern: 'Var god kontrollera värdet',
 		step: 'Värdet måste ökas med {0}',
 		email: 'Fyll i en korrekt e-postadress',


### PR DESCRIPTION
The error message should not suggest the user is required to enter less than maxLength, since the threshold is inclusive.

"Fyll i färre än {0} tecken" translates to "Enter less than {0} characters".
"Fyll inte i fler än {0} tecken" translates to "Do not enter more than {0} characters", which is more correct.
