### PR TITLE
Allow a function als validation message

### DIFF
--- a/src/bindingHandlers.js
+++ b/src/bindingHandlers.js
@@ -78,6 +78,8 @@ ko.bindingHandlers['validationMessage'] = { // individual error message, if modi
 
 		if (config.allowHtmlMessages) {
 			ko.utils.setHtml(element, error);
+    } else if (typeof error == 'function'){
+      ko.bindingHandlers.text.update(element, function () { return error()(); });
 		} else {
 			ko.bindingHandlers.text.update(element, function () { return error; });
 		}

--- a/src/bindingHandlers.js
+++ b/src/bindingHandlers.js
@@ -78,8 +78,8 @@ ko.bindingHandlers['validationMessage'] = { // individual error message, if modi
 
 		if (config.allowHtmlMessages) {
 			ko.utils.setHtml(element, error);
-    } else if (typeof error == 'function'){
-      ko.bindingHandlers.text.update(element, function () { return error()(); });
+		} else if (typeof error == 'function'){
+			ko.bindingHandlers.text.update(element, function () { return error()(); });
 		} else {
 			ko.bindingHandlers.text.update(element, function () { return error; });
 		}


### PR DESCRIPTION
By allowing a function in the `validationMessage` binding, it is possible to for example use another knockout observable as the validation message. The following example is used in our application for dynamically updating the validation message. I18n is provided by i18next.js for the whole application.

```
required: {
    message: function() {
      return i18n.get('validation_required')
    }
}
```
Not sure if any tests are written for this custom binding?