### PR TITLE
When adding a rule, use 'peek' to check the existing rules.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -268,11 +268,12 @@
 		//
 		addRule: function (observable, rule) {
 			observable.extend({ validatable: true });
-
-			var hasRule = !!ko.utils.arrayFirst(observable.rules(), function(item) {
+			//calculate if the observable already has this rule
+			//peek the set of rules so this function does not cause any encapsulating subsciptions to fire if the rules change
+			var hasRule = !!ko.utils.arrayFirst(observable.rules.peek(), function(item) {
 				return item.rule && item.rule === rule.rule;
 			});
-
+			//do not add the rule if it already exists on the observable
 			if (!hasRule) {
 				//push a Rule Context to the observables local array of Rule Contexts
 				observable.rules.push(rule);


### PR DESCRIPTION
This is so that any encapsulating subscriptions won't fire if the rules change.

See #594.