### PR TITLE
Update knockout.validation.js

### DIFF
--- a/dist/knockout.validation.js
+++ b/dist/knockout.validation.js
@@ -1351,7 +1351,9 @@ kv.validateObservable = function (observable) {
 		ctx, // the current Rule Context for the loop
 		ruleContexts = observable.rules(), //cache for iterator
 		len = ruleContexts.length; //cache for iterator
-
+		
+	observable.clearError();
+	
 	for (; i < len; i++) {
 
 		//get the Rule Context info to give to the core Rule
@@ -1376,8 +1378,6 @@ kv.validateObservable = function (observable) {
 			}
 		}
 	}
-	//finally if we got this far, make the observable valid again!
-	observable.clearError();
 	return true;
 };
 ;


### PR DESCRIPTION
Fixed a pretty mean to track down bug which occurs when you have a async validation rule that isn't always actualy async thus there are cases for example if you already found a useful info in your cache where the callback is called with the appropriate validation result immediately after your rules validator function is called. The specific issue only occured if that result should lead to an invalid state, too.
This resulted in validity state to be changed to invalid as expected after that validation rule was processed. But unfortunately immediately after the in the end of the kv.validateObservable function observable.clearError() was called and thus the valid state was reset to be valid again.
I understand that this line is necessary so the invalid fields get actualy relesed once no rule is violated anymore but for the async validation in a rare case this happend to early so i moved that line up which worked just fine for me.