### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ npm install knockout.validation --save
 * https://cdnjs.cloudflare.com/ajax/libs/knockout-validation/2.0.3/knockout.validation.min.js
 
 ##### [jsdelivr](http://www.jsdelivr.com/#!knockout.validation)
-- https://cdn.jsdelivr.net/knockout.validation/2.0.3/knockout.validation.js
-- https://cdn.jsdelivr.net/knockout.validation/2.0.3/knockout.validation.min.js
+- https://cdn.jsdelivr.net/npm/knockout.validation@2.0.3/dist/knockout.validation.js
+- https://cdn.jsdelivr.net/npm/knockout.validation@2.0.3/dist/knockout.validation.min.js
 
 
 ##Getting Started


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/knockout.validation.

Feel free to ping me if you have any questions regarding this change.