### PR TITLE
Inherit configuration from parent node

### DIFF
--- a/src/bindingHandlers.js
+++ b/src/bindingHandlers.js
@@ -151,7 +151,7 @@ ko.bindingHandlers['validationOptions'] = (function () {
 		init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
 			var options = ko.utils.unwrapObservable(valueAccessor());
 			if (options) {
-				var newConfig = ko.utils.extend({}, ko.validation.configuration);
+				var newConfig = ko.utils.extend({}, ko.validation.utils.getConfigOptions(element.parentElement));
 				ko.utils.extend(newConfig, options);
 
 				//store the validation options on the node so we can retrieve it later


### PR DESCRIPTION
Since knockout validation configuration overrides are coupled to specific DOM elements it is often more intuitive and useful to inherit configuration defaults from DOM parent than global configuration.